### PR TITLE
log Intel quote attestation signing certs

### DIFF
--- a/ias_client/Cargo.toml
+++ b/ias_client/Cargo.toml
@@ -12,6 +12,9 @@ futures      = "0.1"
 http         = "0.1"
 hyper        = "0.12"
 kbupd_util   = { path = "../kbupd_util" }
+log          = { version = "0.4", features = ["std"] }
+openssl      = { rev = "ea6761d5e7b63b415b7fda6ba5c5026f4218bcd0", git = "https://github.com/signalapp/rust-openssl.git" }
+openssl-sys  = { rev = "ea6761d5e7b63b415b7fda6ba5c5026f4218bcd0", git = "https://github.com/signalapp/rust-openssl.git" }
 serde        = "1.0"
 serde_derive = "1.0"
 serde_json   = "1.0"

--- a/ias_client/src/lib.rs
+++ b/ias_client/src/lib.rs
@@ -26,6 +26,8 @@ use http::{self, HeaderMap, Uri};
 use hyper::client::connect::Connect;
 use hyper::{Body, Chunk, Client, Method, Request, Response};
 use kbupd_util::base64;
+use log::warn;
+use openssl::x509::X509;
 use serde_derive::{Deserialize, Serialize};
 use serde_json;
 use sgx_sdk_ffi::SgxQuote;
@@ -216,6 +218,19 @@ fn validate_quote_signature(
         return Err(QuoteVerificationError::InvalidCertificates(pem_certificates.to_string()));
     }
 
+    // TODO(KBS-174): remove this logging or make it a return, not a log
+    for (i, cert_bytes) in certificates.iter().enumerate() {
+        let res = X509::from_der(cert_bytes);
+        match res {
+            Ok(_) => {
+                // do nothing
+            }
+            Err(err) => warn!(
+                "unable to parse X-IAS-Report-Signing-Certificate index {} (full bytes: '{}'): {}",
+                i, pem_certificates, err
+            ),
+        }
+    }
     let body = response_body_data.to_vec();
 
     let parsed_body: QuoteSignatureResponseBody =


### PR DESCRIPTION
Parse the certs that signed the quote and log them out. We don't
reject them if they're busted, yet, for fear of how often that might
occur.

Fixes KBS-173