### PR TITLE
Revert "log when Intel quote signing certs are unusual (#8)"

### DIFF
--- a/ias_client/Cargo.toml
+++ b/ias_client/Cargo.toml
@@ -12,7 +12,6 @@ futures      = "0.1"
 http         = "0.1"
 hyper        = "0.12"
 kbupd_util   = { path = "../kbupd_util" }
-log          = { version = "0.4", features = ["std"] }
 serde        = "1.0"
 serde_derive = "1.0"
 serde_json   = "1.0"


### PR DESCRIPTION
This reverts commit 94022e8ea745a2c45caefb3e36cfe51f916697c1.

Now that we know it's an iOS platform bug, we don't need to ship this.